### PR TITLE
[RM] Allows custom config for inline delimiters

### DIFF
--- a/packages/remark-math/inline.js
+++ b/packages/remark-math/inline.js
@@ -9,7 +9,7 @@ const NODE_TYPES = {
   INLINE_MATH: 'inlineMath'
 }
 
-const includeNonDollarsAndEscaped = [/\\\$/, /[^$]/]
+const includeNonDollarsAndEscaped = ['\\$', /[^$]/]
 
 function escapeRegExp (str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -40,7 +40,9 @@ function buildMatchers (modes) {
     const left = escapeRegExp(mode.left)
     const right = escapeRegExp(mode.right)
     const useMatchIncludes = mode.matchIncludes || includeNonDollarsAndEscaped
-    const matchIncludes = useMatchIncludes.map(function (s) { return s.source })
+    const matchIncludes = useMatchIncludes.map(function (s) {
+      return (typeof s === 'string') ? escapeRegExp(s) : s.source
+    })
     const capture = '((?:' + matchIncludes.join('|') + ')+)'
     accum[modeName] = new RegExp('^' + left + capture + right)
     return accum

--- a/packages/remark-math/inline.js
+++ b/packages/remark-math/inline.js
@@ -6,25 +6,25 @@ const ESCAPED_INLINE_MATH = /^\\\$/ // starts with \$
 
 const NODE_TYPES = {
   TEXT: 'text',
-  MATH_INLINE: 'inlineMath'
+  INLINE_MATH: 'inlineMath'
 }
 
 const defaultModes = {
-  mathInlineDouble: {
-    nodeType: NODE_TYPES.MATH_INLINE,
+  inlineMath: {
+    nodeType: NODE_TYPES.INLINE_MATH,
+    left: /\$/,
+    right: /\$/,
+    matchInclude: [/\\\$/, /[^$]/],
+    getClassNames: function () { return ['inlineMath'] }
+  },
+  inlineMathDouble: {
+    nodeType: NODE_TYPES.INLINE_MATH,
     left: /\$\$/,
     right: /\$\$/,
     matchInclude: [/\\\$/, /[^$]/],
     getClassNames: function (opts) {
       return opts && opts.inlineMathDouble ? ['inlineMath', 'inlineMathDouble'] : ['inlineMath']
     }
-  },
-  mathInline: {
-    nodeType: NODE_TYPES.MATH_INLINE,
-    left: /\$/,
-    right: /\$/,
-    matchInclude: [/\\\$/, /[^$]/],
-    getClassNames: function () { return ['inlineMath'] }
   }
 }
 
@@ -68,6 +68,7 @@ module.exports = function inlinePlugin (opts) {
       if (silent) {
         return true
       }
+
       return eat(escaped[0])({
         type: NODE_TYPES.TEXT,
         value: '$'
@@ -118,6 +119,7 @@ module.exports = function inlinePlugin (opts) {
       }
     })
   }
+
   inlineTokenizer.locator = locator
 
   const Parser = this.Parser
@@ -133,7 +135,7 @@ module.exports = function inlinePlugin (opts) {
   // Stringify for math inline
   if (Compiler != null) {
     const visitors = Compiler.prototype.visitors
-    visitors[NODE_TYPES.MATH_INLINE] = function (node) {
+    visitors[NODE_TYPES.INLINE_MATH] = function (node) {
       return '$' + node.value + '$'
     }
   }

--- a/packages/remark-math/inline.js
+++ b/packages/remark-math/inline.js
@@ -15,7 +15,6 @@ const defaultModes = {
     left: /\$\$/,
     right: /\$\$/,
     matchInclude: [/\\\$/, /[^$]/],
-    tagName: 'span',
     getClassNames: function (opts) {
       return opts && opts.inlineMathDouble ? ['inlineMath', 'inlineMathDouble'] : ['inlineMath']
     }
@@ -25,7 +24,6 @@ const defaultModes = {
     left: /\$/,
     right: /\$/,
     matchInclude: [/\\\$/, /[^$]/],
-    tagName: 'span',
     getClassNames: function () { return ['inlineMath'] }
   }
 }
@@ -107,7 +105,7 @@ module.exports = function inlinePlugin (opts) {
       type: mode.nodeType,
       value: matchData.content,
       data: {
-        hName: mode.tagName,
+        hName: 'span',
         hProperties: {
           className: mode.getClassNames(opts).join(' ')
         },

--- a/packages/remark-math/inline.js
+++ b/packages/remark-math/inline.js
@@ -15,6 +15,10 @@ function escapeRegExp (str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
+function getRegExpSource (strOrRegExp) {
+  return (typeof strOrRegExp === 'string') ? escapeRegExp(strOrRegExp) : strOrRegExp.source
+}
+
 const defaultModes = {
   inlineMath: {
     nodeType: NODE_TYPES.INLINE_MATH,
@@ -37,12 +41,10 @@ const defaultModes = {
 function buildMatchers (modes) {
   return Object.keys(modes).reduce(function (accum, modeName) {
     const mode = modes[modeName]
-    const left = escapeRegExp(mode.left)
-    const right = escapeRegExp(mode.right)
+    const left = getRegExpSource(mode.left)
+    const right = getRegExpSource(mode.right)
     const useMatchIncludes = mode.matchIncludes || includeNonDollarsAndEscaped
-    const matchIncludes = useMatchIncludes.map(function (s) {
-      return (typeof s === 'string') ? escapeRegExp(s) : s.source
-    })
+    const matchIncludes = useMatchIncludes.map(getRegExpSource)
     const capture = '((?:' + matchIncludes.join('|') + ')+)'
     accum[modeName] = new RegExp('^' + left + capture + right)
     return accum

--- a/packages/remark-math/inline.js
+++ b/packages/remark-math/inline.js
@@ -9,19 +9,21 @@ const NODE_TYPES = {
   INLINE_MATH: 'inlineMath'
 }
 
+const includeNonDollarsAndEscaped = [/\\\$/, /[^$]/]
+
 const defaultModes = {
   inlineMath: {
     nodeType: NODE_TYPES.INLINE_MATH,
     left: /\$/,
     right: /\$/,
-    matchInclude: [/\\\$/, /[^$]/],
+    matchInclude: includeNonDollarsAndEscaped,
     getClassNames: function () { return ['inlineMath'] }
   },
   inlineMathDouble: {
     nodeType: NODE_TYPES.INLINE_MATH,
     left: /\$\$/,
     right: /\$\$/,
-    matchInclude: [/\\\$/, /[^$]/],
+    matchInclude: includeNonDollarsAndEscaped,
     getClassNames: function (opts) {
       return opts && opts.inlineMathDouble ? ['inlineMath', 'inlineMathDouble'] : ['inlineMath']
     }
@@ -33,7 +35,8 @@ function buildMatchers (modes) {
     const mode = modes[modeName]
     const left = mode.left.source
     const right = mode.right.source
-    const matchInclude = mode.matchInclude.map(function (s) { return s.source })
+    const useMatchInclude = mode.matchInclude || includeNonDollarsAndEscaped
+    const matchInclude = useMatchInclude.map(function (s) { return s.source })
     const capture = '((?:' + matchInclude.join('|') + ')+)'
     accum[modeName] = new RegExp('^' + left + capture + right)
     return accum

--- a/packages/remark-math/inline.js
+++ b/packages/remark-math/inline.js
@@ -20,14 +20,14 @@ const defaultModes = {
     nodeType: NODE_TYPES.INLINE_MATH,
     left: '$',
     right: '$',
-    matchInclude: includeNonDollarsAndEscaped,
+    matchIncludes: includeNonDollarsAndEscaped,
     getClassNames: function () { return ['inlineMath'] }
   },
   inlineMathDouble: {
     nodeType: NODE_TYPES.INLINE_MATH,
     left: '$$',
     right: '$$',
-    matchInclude: includeNonDollarsAndEscaped,
+    matchIncludes: includeNonDollarsAndEscaped,
     getClassNames: function (opts) {
       return opts && opts.inlineMathDouble ? ['inlineMath', 'inlineMathDouble'] : ['inlineMath']
     }
@@ -39,9 +39,9 @@ function buildMatchers (modes) {
     const mode = modes[modeName]
     const left = escapeRegExp(mode.left)
     const right = escapeRegExp(mode.right)
-    const useMatchInclude = mode.matchInclude || includeNonDollarsAndEscaped
-    const matchInclude = useMatchInclude.map(function (s) { return s.source })
-    const capture = '((?:' + matchInclude.join('|') + ')+)'
+    const useMatchIncludes = mode.matchIncludes || includeNonDollarsAndEscaped
+    const matchIncludes = useMatchIncludes.map(function (s) { return s.source })
+    const capture = '((?:' + matchIncludes.join('|') + ')+)'
     accum[modeName] = new RegExp('^' + left + capture + right)
     return accum
   }, {})

--- a/packages/remark-math/inline.js
+++ b/packages/remark-math/inline.js
@@ -11,18 +11,22 @@ const NODE_TYPES = {
 
 const includeNonDollarsAndEscaped = [/\\\$/, /[^$]/]
 
+function escapeRegExp (str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 const defaultModes = {
   inlineMath: {
     nodeType: NODE_TYPES.INLINE_MATH,
-    left: /\$/,
-    right: /\$/,
+    left: '$',
+    right: '$',
     matchInclude: includeNonDollarsAndEscaped,
     getClassNames: function () { return ['inlineMath'] }
   },
   inlineMathDouble: {
     nodeType: NODE_TYPES.INLINE_MATH,
-    left: /\$\$/,
-    right: /\$\$/,
+    left: '$$',
+    right: '$$',
     matchInclude: includeNonDollarsAndEscaped,
     getClassNames: function (opts) {
       return opts && opts.inlineMathDouble ? ['inlineMath', 'inlineMathDouble'] : ['inlineMath']
@@ -33,8 +37,8 @@ const defaultModes = {
 function buildMatchers (modes) {
   return Object.keys(modes).reduce(function (accum, modeName) {
     const mode = modes[modeName]
-    const left = mode.left.source
-    const right = mode.right.source
+    const left = escapeRegExp(mode.left)
+    const right = escapeRegExp(mode.right)
     const useMatchInclude = mode.matchInclude || includeNonDollarsAndEscaped
     const matchInclude = useMatchInclude.map(function (s) { return s.source })
     const capture = '((?:' + matchInclude.join('|') + ')+)'

--- a/packages/remark-math/inline.js
+++ b/packages/remark-math/inline.js
@@ -11,8 +11,9 @@ const NODE_TYPES = {
 
 const includeNonDollarsAndEscaped = ['\\$', /[^$]/]
 
+// Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
 function escapeRegExp (str) {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return str.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&');
 }
 
 function getRegExpSource (strOrRegExp) {

--- a/packages/remark-math/inline.js
+++ b/packages/remark-math/inline.js
@@ -2,72 +2,124 @@ function locator (value, fromIndex) {
   return value.indexOf('$', fromIndex)
 }
 
-const ESCAPED_INLINE_MATH = /^\\\$/
-const INLINE_MATH = /^\$((?:\\\$|[^$])+)\$/
-const INLINE_MATH_DOUBLE = /^\$\$((?:\\\$|[^$])+)\$\$/
+const ESCAPED_INLINE_MATH = /^\\\$/ // starts with \$
+
+const NODE_TYPES = {
+  TEXT: 'text',
+  MATH_DISPLAY: 'math',
+  MATH_INLINE: 'inlineMath'
+}
+
+const defaultModes = {
+  mathInlineDouble: {
+    nodeType: NODE_TYPES.MATH_INLINE,
+    left: /\$\$/,
+    right: /\$\$/,
+    matchInclude: [/\\\$/, /[^$]/],
+    tagName: 'span',
+    getClassNames: function (opts) {
+      return opts && opts.inlineMathDouble ? ['inlineMath', 'inlineMathDouble'] : ['inlineMath']
+    }
+  },
+  mathInline: {
+    nodeType: NODE_TYPES.MATH_INLINE,
+    left: /\$/,
+    right: /\$/,
+    matchInclude: [/\\\$/, /[^$]/],
+    tagName: 'span',
+    getClassNames: function () { return ['inlineMath'] }
+  }
+}
+
+function buildMatchers (modes) {
+  return Object.keys(modes).reduce(function (accum, modeName) {
+    const mode = modes[modeName]
+    const left = mode.left.source
+    const right = mode.right.source
+    const matchInclude = mode.matchInclude.map(function (s) { return s.source })
+    const capture = '((?:' + matchInclude.join('|') + ')+)'
+    accum[modeName] = new RegExp('^' + left + capture + right)
+    return accum
+  }, {})
+}
+
+function findMatch (matchers, value) {
+  let modeName = null
+  let match = null
+  for (modeName in matchers) {
+    const matcher = matchers[modeName]
+    match = matcher.exec(value)
+    if (match) {
+      break
+    }
+  }
+
+  return match && { modeName, match, fullMatch: match[0], content: match[1].trim() }
+}
 
 module.exports = function inlinePlugin (opts) {
-  function inlineTokenizer (eat, value, silent) {
-    let isDouble = true
-    let match = INLINE_MATH_DOUBLE.exec(value)
-    if (!match && !opts.disableInlineMathSingle) {
-      match = INLINE_MATH.exec(value)
-      isDouble = false
-    }
-    const escaped = ESCAPED_INLINE_MATH.exec(value)
+  const modes = (opts && opts.modes) || defaultModes
 
+  const matchers = buildMatchers(modes)
+
+  function inlineTokenizer (eat, value, silent) {
+    const matchData = findMatch(matchers, value)
+
+    const escaped = ESCAPED_INLINE_MATH.exec(value)
     if (escaped) {
       /* istanbul ignore if - never used (yet) */
       if (silent) {
         return true
       }
       return eat(escaped[0])({
-        type: 'text',
+        type: NODE_TYPES.TEXT,
         value: '$'
       })
     }
 
-    if (value.slice(-2) === '\\$') {
+    if (value.slice(-2) === '\\$') { // ends with \$
       return eat(value)({
-        type: 'text',
+        type: NODE_TYPES.TEXT,
         value: value.slice(0, -2) + '$'
       })
     }
 
-    if (match) {
-      /* istanbul ignore if - never used (yet) */
-      if (silent) {
-        return true
-      }
+    if (!matchData) {
+      return
+    }
 
-      const endingDollarInBackticks = match[0].includes('`') && value.slice(match[0].length).includes('`')
-      if (endingDollarInBackticks) {
-        const toEat = value.slice(0, value.indexOf('`'))
-        return eat(toEat)({
-          type: 'text',
-          value: toEat
-        })
-      }
+    /* istanbul ignore if - never used (yet) */
+    if (silent) {
+      return true
+    }
 
-      const trimmedContent = match[1].trim()
-
-      return eat(match[0])({
-        type: 'inlineMath',
-        value: trimmedContent,
-        data: {
-          hName: 'span',
-          hProperties: {
-            className: 'inlineMath' + (isDouble && opts.inlineMathDouble ? ' inlineMathDouble' : '')
-          },
-          hChildren: [
-            {
-              type: 'text',
-              value: trimmedContent
-            }
-          ]
-        }
+    const fullMatch = matchData.fullMatch
+    const endingDollarInBackticks = fullMatch.includes('`') && value.slice(fullMatch.length).includes('`')
+    if (endingDollarInBackticks) {
+      const toEat = value.slice(0, value.indexOf('`'))
+      return eat(toEat)({
+        type: NODE_TYPES.TEXT,
+        value: toEat
       })
     }
+
+    const mode = modes[matchData.modeName]
+    return eat(fullMatch)({
+      type: mode.nodeType,
+      value: matchData.content,
+      data: {
+        hName: mode.tagName,
+        hProperties: {
+          className: mode.getClassNames(opts).join(' ')
+        },
+        hChildren: [
+          {
+            type: NODE_TYPES.TEXT,
+            value: matchData.content
+          }
+        ]
+      }
+    })
   }
   inlineTokenizer.locator = locator
 
@@ -76,15 +128,15 @@ module.exports = function inlinePlugin (opts) {
   // Inject inlineTokenizer
   const inlineTokenizers = Parser.prototype.inlineTokenizers
   const inlineMethods = Parser.prototype.inlineMethods
-  inlineTokenizers.math = inlineTokenizer
-  inlineMethods.splice(inlineMethods.indexOf('text'), 0, 'math')
+  inlineTokenizers[NODE_TYPES.MATH_DISPLAY] = inlineTokenizer
+  inlineMethods.splice(inlineMethods.indexOf(NODE_TYPES.TEXT), 0, NODE_TYPES.MATH_DISPLAY)
 
   const Compiler = this.Compiler
 
   // Stringify for math inline
   if (Compiler != null) {
     const visitors = Compiler.prototype.visitors
-    visitors.inlineMath = function (node) {
+    visitors[NODE_TYPES.MATH_INLINE] = function (node) {
       return '$' + node.value + '$'
     }
   }

--- a/packages/remark-math/inline.js
+++ b/packages/remark-math/inline.js
@@ -6,7 +6,6 @@ const ESCAPED_INLINE_MATH = /^\\\$/ // starts with \$
 
 const NODE_TYPES = {
   TEXT: 'text',
-  MATH_DISPLAY: 'math',
   MATH_INLINE: 'inlineMath'
 }
 
@@ -128,8 +127,8 @@ module.exports = function inlinePlugin (opts) {
   // Inject inlineTokenizer
   const inlineTokenizers = Parser.prototype.inlineTokenizers
   const inlineMethods = Parser.prototype.inlineMethods
-  inlineTokenizers[NODE_TYPES.MATH_DISPLAY] = inlineTokenizer
-  inlineMethods.splice(inlineMethods.indexOf(NODE_TYPES.TEXT), 0, NODE_TYPES.MATH_DISPLAY)
+  inlineTokenizers.math = inlineTokenizer
+  inlineMethods.splice(inlineMethods.indexOf('text'), 0, 'math')
 
   const Compiler = this.Compiler
 

--- a/packages/remark-math/package-lock.json
+++ b/packages/remark-math/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gradescope/remark-math",
-  "version": "1.1.0-alpha.4",
+  "version": "1.1.0-alpha.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/remark-math/package.json
+++ b/packages/remark-math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gradescope/remark-math",
-  "version": "1.1.0-alpha.4",
+  "version": "1.1.0-alpha.5",
   "description": "Math Inline and Block parser plugin for Remark",
   "publishConfig": {
     "registry": "http://bin-repo.iparadigms.com/artifactory/api/npm/am-npm/"

--- a/specs/remark-math.spec.js
+++ b/specs/remark-math.spec.js
@@ -351,7 +351,6 @@ it('accepts a custom configuration', () => {
       left: /\$\$\$/,
       right: /\$\$\$/,
       matchInclude: [/\\\$/, /[^$]/],
-      tagName: 'div',
       getClassNames: function () { return ['math', 'math-display'] }
     },
     mathInline: {
@@ -359,7 +358,6 @@ it('accepts a custom configuration', () => {
       left: /\$\$/,
       right: /\$\$/,
       matchInclude: [/\\\$/, /[^$]/],
-      tagName: 'span',
       getClassNames: function () { return ['inlineMath', 'math-inline'] }
     }
   }
@@ -397,7 +395,7 @@ it('accepts a custom configuration', () => {
           hChildren: [
             u('text', '\\gamma')
           ],
-          hName: 'div',
+          hName: 'span',
           hProperties: {
             className: 'math math-display'
           }

--- a/specs/remark-math.spec.js
+++ b/specs/remark-math.spec.js
@@ -350,14 +350,14 @@ it('accepts a custom configuration', () => {
       nodeType: 'inlineMath',
       left: '$$',
       right: '$$',
-      matchIncludes: [/\\\$/, /[^$]/],
+      matchIncludes: ['\\$', /[^$]/],
       getClassNames: function () { return ['inlineMath', 'math-inline'] }
     },
     displayMath: {
       nodeType: 'math',
       left: '$$$',
       right: '$$$',
-      matchIncludes: [/\\\$/, /[^$]/],
+      matchIncludes: ['\\$', /[^$]/],
       getClassNames: function () { return ['math', 'math-display'] }
     }
   }

--- a/specs/remark-math.spec.js
+++ b/specs/remark-math.spec.js
@@ -348,15 +348,15 @@ it('accepts a custom configuration', () => {
   const customModes = {
     inlineMath: {
       nodeType: 'inlineMath',
-      left: /\$\$/,
-      right: /\$\$/,
+      left: '$$',
+      right: '$$',
       matchInclude: [/\\\$/, /[^$]/],
       getClassNames: function () { return ['inlineMath', 'math-inline'] }
     },
     displayMath: {
       nodeType: 'math',
-      left: /\$\$\$/,
-      right: /\$\$\$/,
+      left: '$$$',
+      right: '$$$',
       matchInclude: [/\\\$/, /[^$]/],
       getClassNames: function () { return ['math', 'math-display'] }
     }

--- a/specs/remark-math.spec.js
+++ b/specs/remark-math.spec.js
@@ -343,3 +343,67 @@ it('must set inlineMathDouble class if inlineMathDouble is true', () => {
     ])
   ]))
 })
+
+it('accepts a custom configuration', () => {
+  const customModes = {
+    mathDisplay: {
+      nodeType: 'math',
+      left: /\$\$\$/,
+      right: /\$\$\$/,
+      matchInclude: [/\\\$/, /[^$]/],
+      tagName: 'div',
+      getClassNames: function () { return ['math', 'math-display'] }
+    },
+    mathInline: {
+      nodeType: 'inlineMath',
+      left: /\$\$/,
+      right: /\$\$/,
+      matchInclude: [/\\\$/, /[^$]/],
+      tagName: 'span',
+      getClassNames: function () { return ['inlineMath', 'math-inline'] }
+    }
+  }
+
+  const processor = remark()
+    .use(math, {
+      modes: customModes
+    })
+
+  const targetText = [
+    'treat this as text $\\alpha$!',
+    'treat this as inline $$\\beta$$!',
+    'treat this as display $$$\\gamma$$$!'
+  ].join('\n')
+
+  const ast = processor.parse(targetText)
+
+  expect(ast).toEqual(u('root', [
+    u('paragraph', [
+      u('text', 'treat this as text $\\alpha$!\ntreat this as inline '),
+      u('inlineMath', {
+        data: {
+          hChildren: [
+            u('text', '\\beta')
+          ],
+          hName: 'span',
+          hProperties: {
+            className: 'inlineMath math-inline'
+          }
+        }
+      }, '\\beta'),
+      u('text', '!\ntreat this as display '),
+      u('math', {
+        data: {
+          hChildren: [
+            u('text', '\\gamma')
+          ],
+          hName: 'div',
+          hProperties: {
+            className: 'math math-display'
+          }
+        }
+      }, '\\gamma'),
+      u('text', '!')
+    ])
+  ]))
+})

--- a/specs/remark-math.spec.js
+++ b/specs/remark-math.spec.js
@@ -350,14 +350,14 @@ it('accepts a custom configuration', () => {
       nodeType: 'inlineMath',
       left: '$$',
       right: '$$',
-      matchInclude: [/\\\$/, /[^$]/],
+      matchIncludes: [/\\\$/, /[^$]/],
       getClassNames: function () { return ['inlineMath', 'math-inline'] }
     },
     displayMath: {
       nodeType: 'math',
       left: '$$$',
       right: '$$$',
-      matchInclude: [/\\\$/, /[^$]/],
+      matchIncludes: [/\\\$/, /[^$]/],
       getClassNames: function () { return ['math', 'math-display'] }
     }
   }

--- a/specs/remark-math.spec.js
+++ b/specs/remark-math.spec.js
@@ -346,19 +346,19 @@ it('must set inlineMathDouble class if inlineMathDouble is true', () => {
 
 it('accepts a custom configuration', () => {
   const customModes = {
-    mathDisplay: {
-      nodeType: 'math',
-      left: /\$\$\$/,
-      right: /\$\$\$/,
-      matchInclude: [/\\\$/, /[^$]/],
-      getClassNames: function () { return ['math', 'math-display'] }
-    },
-    mathInline: {
+    inlineMath: {
       nodeType: 'inlineMath',
       left: /\$\$/,
       right: /\$\$/,
       matchInclude: [/\\\$/, /[^$]/],
       getClassNames: function () { return ['inlineMath', 'math-inline'] }
+    },
+    displayMath: {
+      nodeType: 'math',
+      left: /\$\$\$/,
+      right: /\$\$\$/,
+      matchInclude: [/\\\$/, /[^$]/],
+      getClassNames: function () { return ['math', 'math-display'] }
     }
   }
 


### PR DESCRIPTION
These changes allow the consuming application to pass in a custom
configuration for parsing Remark-Math segments inline.

The intended use case is that delimiters can indicate either Inline Mode
or Display (Block) Mode, depending on the delimiter used, and custom
delimiters for either of these.

For the particular use case we are applying, we don't want
single-dollar-sign delimited strings to be interpreted as LaTeX at all,
in case users are intending them to indicate regular text, in possible
ignorance of LaTeX. Instead, we want double-dollar-signs to be used to
indicate Inline Mode, and triple-dollar-signs to be used to indicate
Display (Block) Mode. A test has been added for this configuration.

[CH-25113](https://app.clubhouse.io/gradescope/story/25113/remark-math-supports-for-block-latex)